### PR TITLE
Fix readonly allCmdlist is changed issue.

### DIFF
--- a/www/poker/poker.js
+++ b/www/poker/poker.js
@@ -182,7 +182,7 @@ function saveCard(theCard, theCmd) {
 	  }
 	});
 	theCmd.empty();
-	theCmd.append(selectCmdXml[0]);
+	theCmd.append(selectCmdXml[0].cloneNode(true));
 	theCard.find(".cmdDesc").text(selectCmd);
 	theCard.find(".execTime").text("0.0 seconds");
 }


### PR DESCRIPTION
After clicking on the save card button, allCmdlist is changed. But
it is supposed to be readonly. The root cause is append method will
remove this XML node from its parent node.