### PR TITLE
fixes mandatory parameter attribute

### DIFF
--- a/powershell/genDefJson.ps1
+++ b/powershell/genDefJson.ps1
@@ -140,7 +140,7 @@ function newCommand {
         helpmessage = $helpmsg
       }
       if ($options) { $parameter | add-member options $options }
-      if ($pAttr.mandatory) { $parameter | add-member mandatory 1 }
+      if ($pAttr.mandatory | Select -Unique) { $parameter | add-member mandatory 1 }
       if ($type) { $parameter | add-member "type" $type }
       if ($sets) { $parameter | add-member parametersets @($sets | sort) }
       $parameters += $parameter

--- a/powershell/genDefJson.ps1
+++ b/powershell/genDefJson.ps1
@@ -159,7 +159,7 @@ function newCommand {
   }
   if ($parameters) { $command | add-member parameters $parameters}
   
-  $command | convertto-json -depth 5 | 
+  $command | convertto-json -depth 5 -compress | 
   set-content ($cmd.definition -replace ".ps1", ".json")
   
   return $command


### PR DESCRIPTION
This update fixes the issue where if a parameter is assigned to multiple ParameterSet it is set to mandatory = $true. 