### PR TITLE
Added TLS1.2 as Security Protocol

### DIFF
--- a/powershell/Install/setup.ps1
+++ b/powershell/Install/setup.ps1
@@ -67,6 +67,7 @@ $download = {
 		write-output "`t WPI downloaded successfully."
 	}
 	write-output "Downloading WebCommander package..."
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 	$webClient.downloadfile($packageUrl, "C:\WebCommander\$packageName")
 	write-output "`t WebCommander package downloaded successfully"
 }


### PR DESCRIPTION
DownloadFile from github (https://github.com/vmware/webcommander/archive/master.zip) will raise the following exception *The request was aborted: Could not create SSL/TLS secure channel.*.

This is due to the fact that Powershell, by default, allows TLS 1.0 (see further information [here](https://stackoverflow.com/questions/41618766/powershell-invoke-webrequest-fails-with-ssl-tls-secure-channel)) while github does not allow it anymore (see [here](https://githubengineering.com/crypto-removal-notice/)).